### PR TITLE
Add color to Topic and Aspect

### DIFF
--- a/src/composables/useAspect.js
+++ b/src/composables/useAspect.js
@@ -25,6 +25,7 @@ const aspectClassesByRGB = {
 /**
  * @typedef Aspect
  * @property {string} label
+ * @property {string} color
  * @property {boolean} inSchlag
  * @property {number} fraction
  * @property {boolean} visible
@@ -43,6 +44,7 @@ mapReady.then(() => {
       if (!(cur in acc)) {
         acc[cur] = ({
           label: cur,
+          color: `rgb(${Object.keys(aspectClassesByRGB)[Object.values(aspectClassesByRGB).indexOf(cur)]})`,
           fraction: 0,
           inSchlag: false,
           visible: false,

--- a/src/composables/useTopics.js
+++ b/src/composables/useTopics.js
@@ -12,6 +12,7 @@ import { schlagInfo } from './useSchlag';
 /**
  * @typedef Topic
  * @property {string} label
+ * @property {string} color
  * @property {boolean} inExtent
  * @property {boolean} inSchlagExtent
  * @property {boolean} visible
@@ -23,10 +24,11 @@ mapReady.then(() => {
   const { layers } = map.get('mapbox-style');
   topics.push(...Object.values(layers
     .filter((l) => l.metadata?.group === 'one' && l.type !== 'raster')
-    .map((l) => l.metadata?.label).reduce((acc, cur) => {
-      if (!(cur in acc)) {
-        acc[cur] = ({
-          label: cur,
+    .map((l) => ({ label: l.metadata?.label, color: l.paint?.['fill-color'] })).reduce((acc, { label, color }) => {
+      if (!(label in acc)) {
+        acc[label] = ({
+          label,
+          color,
           inExtent: false,
           inSchlagExtent: false,
           visible: false,


### PR DESCRIPTION
Die `Topic` und `Aspect` Objekte haben nun ein weiteres Attribut `color`. Dieses enthält die Legendenfarbe.

@arnold-pichler:
* ACHTUNG: Die Opacity (in der `ref` `opacity`) muss zusätzlich berücksichtigt werden, um in der Legende die passende Darstellung zu bekommen.
* Um das Legendensymbol für die Übersicht aller Themen zu bekommen, am besten `./map/hatch-any.svg` als `background-image` mit `repeat` verwenden.