### PR TITLE
Apply topic filter on all zoom levels

### DIFF
--- a/src/composables/useTopics.js
+++ b/src/composables/useTopics.js
@@ -64,17 +64,11 @@ async function findRenderedTopics(extent) {
 
 /** @returns {Promise<void>} */
 async function updateTopicsInExtent() {
-  const { extent, zoom } = mapView.value;
-  if (zoom < 12) {
-    topics.forEach((topic) => {
-      topic.inExtent = true;
-    });
-  } else {
-    const renderedTopics = await findRenderedTopics(transformExtent(extent, 'EPSG:4326', 'EPSG:3857'));
-    topics.forEach((topic) => {
-      topic.inExtent = renderedTopics.includes(topic.label);
-    });
-  }
+  const { extent } = mapView.value;
+  const renderedTopics = await findRenderedTopics(transformExtent(extent, 'EPSG:4326', 'EPSG:3857'));
+  topics.forEach((topic) => {
+    topic.inExtent = renderedTopics.includes(topic.label);
+  });
 }
 
 /** @returns {Promise<void>|undefined} */


### PR DESCRIPTION
Aktiviert den Themenfilter wieder für alle Zoomstufen. Das geht ein wenig auf die Performance, führt aber auch dazu, dass einzelne Themen bei der Österreich-Ansicht nicht in der Liste sind, weil sie auf niedrigen Zoomstufen weggeneralisiert werden. Aber insgesamt ist das Verhalten dadurch konsistenter, jetzt wo es keine Zoomstufen-Filter Checkbox mehr gibt.