### PR TITLE
Rename base map

### DIFF
--- a/public/map/style.json
+++ b/public/map/style.json
@@ -105,7 +105,7 @@
     }
   },
   "layers": [{
-    "id": "Übersichtskarte",
+    "id": "basemap.at",
     "type": "raster",
     "source": "geolandbasemap",
     "metadata": {

--- a/src/components/TheBaseLayerSwitcher.vue
+++ b/src/components/TheBaseLayerSwitcher.vue
@@ -48,8 +48,8 @@
         cols="6"
         align="center"
         class="mapMode pa-2"
-        :class="{selected : baseLayer=='Übersichtskarte'}"
-        @click="switchMode('Übersichtskarte')"
+        :class="{selected : baseLayer=='basemap.at'}"
+        @click="switchMode('basemap.at')"
       >
         <v-img
           :src="topo"
@@ -58,7 +58,7 @@
           height="90"
           class="mb-1"
         /><div class="text-caption">
-          <span>Übersichtskarte</span>
+          <span>basemap.at</span>
         </div>
       </v-col>
       <v-col

--- a/src/components/TheTopicPanel.vue
+++ b/src/components/TheTopicPanel.vue
@@ -83,7 +83,7 @@
               <v-col cols="10">
                 <v-radio
                   key="-2"
-                  label="Nur Hintergrundkarte"
+                  label="Nur Basiskarte"
                   value="none"
                   density="compact"
                 />


### PR DESCRIPTION
Verwendung des Namens "basemap.at" statt "Übersichtskarte"
