### PR TITLE
Add deploy-release action

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -1,0 +1,32 @@
+name: Continuous Deployment Dev
+
+on:
+  push:
+    tags:
+      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+
+jobs:
+  build-and-deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - run: |
+        npm ci
+        npm run build
+
+    - uses: BetaHuhn/do-spaces-action@v2.0.58
+      with:
+        access_key: ${{ secrets.S3_KEY }}
+        secret_key: ${{ secrets.S3_SECRET }}
+        space_name: 'w3geo'
+        space_region: 'fra1'
+        source: 'dist'
+        out_dir: 'agraratlas'
+


### PR DESCRIPTION
Adds an action to deploy release tags to a different s3 folder than the main branch, for a clean separation of development and production.