### PR TITLE
Add Bio-Schläge and use true, variable buffers around topics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "1.0.1",
       "dependencies": {
         "@mdi/font": "5.9.55",
+        "@turf/boolean-intersects": "^6.5.0",
+        "@turf/buffer": "^6.5.0",
         "ol": "^7.1.1-dev.1663363305046",
         "ol-mapbox-style": "^9.1.0",
         "roboto-fontface": "*",
@@ -244,6 +246,181 @@
       "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.6.5.tgz",
       "integrity": "sha512-m5ox8pj4LfAoTO2GqrqCCD9hNX3I73+Dv2pvdGKFHkNHWQh9Z4q/5Du5+ZBYYotneqrliFWR8olMSdnPhmjU2w=="
     },
+    "node_modules/@turf/bbox": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-6.5.0.tgz",
+      "integrity": "sha512-RBbLaao5hXTYyyg577iuMtDB8ehxMlUqHEJiMs8jT1GHkFhr6sYre3lmLsPeYEi/ZKj5TP5tt7fkzNdJ4GIVyw==",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0",
+        "@turf/meta": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-disjoint": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-disjoint/-/boolean-disjoint-6.5.0.tgz",
+      "integrity": "sha512-rZ2ozlrRLIAGo2bjQ/ZUu4oZ/+ZjGvLkN5CKXSKBcu6xFO6k2bgqeM8a1836tAW+Pqp/ZFsTA5fZHsJZvP2D5g==",
+      "dependencies": {
+        "@turf/boolean-point-in-polygon": "^6.5.0",
+        "@turf/helpers": "^6.5.0",
+        "@turf/line-intersect": "^6.5.0",
+        "@turf/meta": "^6.5.0",
+        "@turf/polygon-to-line": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-intersects": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-intersects/-/boolean-intersects-6.5.0.tgz",
+      "integrity": "sha512-nIxkizjRdjKCYFQMnml6cjPsDOBCThrt+nkqtSEcxkKMhAQj5OO7o2CecioNTaX8EayqwMGVKcsz27oP4mKPTw==",
+      "dependencies": {
+        "@turf/boolean-disjoint": "^6.5.0",
+        "@turf/helpers": "^6.5.0",
+        "@turf/meta": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/boolean-point-in-polygon": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-6.5.0.tgz",
+      "integrity": "sha512-DtSuVFB26SI+hj0SjrvXowGTUCHlgevPAIsukssW6BG5MlNSBQAo70wpICBNJL6RjukXg8d2eXaAWuD/CqL00A==",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0",
+        "@turf/invariant": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/buffer": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/buffer/-/buffer-6.5.0.tgz",
+      "integrity": "sha512-qeX4N6+PPWbKqp1AVkBVWFerGjMYMUyencwfnkCesoznU6qvfugFHNAngNqIBVnJjZ5n8IFyOf+akcxnrt9sNg==",
+      "dependencies": {
+        "@turf/bbox": "^6.5.0",
+        "@turf/center": "^6.5.0",
+        "@turf/helpers": "^6.5.0",
+        "@turf/meta": "^6.5.0",
+        "@turf/projection": "^6.5.0",
+        "d3-geo": "1.7.1",
+        "turf-jsts": "*"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/center": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/center/-/center-6.5.0.tgz",
+      "integrity": "sha512-T8KtMTfSATWcAX088rEDKjyvQCBkUsLnK/Txb6/8WUXIeOZyHu42G7MkdkHRoHtwieLdduDdmPLFyTdG5/e7ZQ==",
+      "dependencies": {
+        "@turf/bbox": "^6.5.0",
+        "@turf/helpers": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/clone": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-6.5.0.tgz",
+      "integrity": "sha512-mzVtTFj/QycXOn6ig+annKrM6ZlimreKYz6f/GSERytOpgzodbQyOgkfwru100O1KQhhjSudKK4DsQ0oyi9cTw==",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/helpers": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
+      "integrity": "sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw==",
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/invariant": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.5.0.tgz",
+      "integrity": "sha512-Wv8PRNCtPD31UVbdJE/KVAWKe7l6US+lJItRR/HOEW3eh+U/JwRCSUl/KZ7bmjM/C+zLNoreM2TU6OoLACs4eg==",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-intersect": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-6.5.0.tgz",
+      "integrity": "sha512-CS6R1tZvVQD390G9Ea4pmpM6mJGPWoL82jD46y0q1KSor9s6HupMIo1kY4Ny+AEYQl9jd21V3Scz20eldpbTVA==",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0",
+        "@turf/invariant": "^6.5.0",
+        "@turf/line-segment": "^6.5.0",
+        "@turf/meta": "^6.5.0",
+        "geojson-rbush": "3.x"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-segment": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-6.5.0.tgz",
+      "integrity": "sha512-jI625Ho4jSuJESNq66Mmi290ZJ5pPZiQZruPVpmHkUw257Pew0alMmb6YrqYNnLUuiVVONxAAKXUVeeUGtycfw==",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0",
+        "@turf/invariant": "^6.5.0",
+        "@turf/meta": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/meta": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.5.0.tgz",
+      "integrity": "sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/polygon-to-line": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/polygon-to-line/-/polygon-to-line-6.5.0.tgz",
+      "integrity": "sha512-5p4n/ij97EIttAq+ewSnKt0ruvuM+LIDzuczSzuHTpq4oS7Oq8yqg5TQ4nzMVuK41r/tALCk7nAoBuw3Su4Gcw==",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0",
+        "@turf/invariant": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/projection": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-6.5.0.tgz",
+      "integrity": "sha512-/Pgh9mDvQWWu8HRxqpM+tKz8OzgauV+DiOcr3FCjD6ubDnrrmMJlsf6fFJmggw93mtVPrZRL6yyi9aYCQBOIvg==",
+      "dependencies": {
+        "@turf/clone": "^6.5.0",
+        "@turf/helpers": "^6.5.0",
+        "@turf/meta": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
     "node_modules/@types/eslint": {
       "version": "8.4.5",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.5.tgz",
@@ -272,6 +449,11 @@
       "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.8",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.8.tgz",
+      "integrity": "sha512-1rkryxURpr6aWP7R786/UQOkJ3PcpQiWkAXBmdWc7ryFWqN6a4xfK7BtjXvFBKO9LjQ+MWQSWxYeZX1OApnArA=="
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
@@ -946,6 +1128,19 @@
       "version": "2.6.20",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.20.tgz",
       "integrity": "sha512-/WwNkdXfckNgw6S5R125rrW8ez139lBHWouiBvX8dfMFtcn6V81REDqnH7+CRpRipfYlyU1CmOnOxrmGcFOjeA=="
+    },
+    "node_modules/d3-array": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+    },
+    "node_modules/d3-geo": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.7.1.tgz",
+      "integrity": "sha512-O4AempWAr+P5qbk2bC2FuN/sDW4z+dN2wDf9QV3bxQt4M5HfOEeXLgJ/UKQW0+o1Dj8BE+L5kiDbdWUMjsmQpw==",
+      "dependencies": {
+        "d3-array": "1"
+      }
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -2027,6 +2222,18 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/geojson-rbush": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/geojson-rbush/-/geojson-rbush-3.2.0.tgz",
+      "integrity": "sha512-oVltQTXolxvsz1sZnutlSuLDEcQAKYC/uXt9zDzJJ6bu0W+baTI8LZBaTup5afzibEH4N3jlq2p+a152wlBJ7w==",
+      "dependencies": {
+        "@turf/bbox": "*",
+        "@turf/helpers": "6.x",
+        "@turf/meta": "6.x",
+        "@types/geojson": "7946.0.8",
+        "rbush": "^3.0.1"
       }
     },
     "node_modules/geotiff": {
@@ -3718,6 +3925,11 @@
         "json5": "lib/cli.js"
       }
     },
+    "node_modules/turf-jsts": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/turf-jsts/-/turf-jsts-1.2.3.tgz",
+      "integrity": "sha512-Ja03QIJlPuHt4IQ2FfGex4F4JAr8m3jpaHbFbQrgwr7s7L6U8ocrHiF3J1+wf9jzhGKxvDeaCAnGDot8OjGFyA=="
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -4312,6 +4524,139 @@
       "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.6.5.tgz",
       "integrity": "sha512-m5ox8pj4LfAoTO2GqrqCCD9hNX3I73+Dv2pvdGKFHkNHWQh9Z4q/5Du5+ZBYYotneqrliFWR8olMSdnPhmjU2w=="
     },
+    "@turf/bbox": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-6.5.0.tgz",
+      "integrity": "sha512-RBbLaao5hXTYyyg577iuMtDB8ehxMlUqHEJiMs8jT1GHkFhr6sYre3lmLsPeYEi/ZKj5TP5tt7fkzNdJ4GIVyw==",
+      "requires": {
+        "@turf/helpers": "^6.5.0",
+        "@turf/meta": "^6.5.0"
+      }
+    },
+    "@turf/boolean-disjoint": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-disjoint/-/boolean-disjoint-6.5.0.tgz",
+      "integrity": "sha512-rZ2ozlrRLIAGo2bjQ/ZUu4oZ/+ZjGvLkN5CKXSKBcu6xFO6k2bgqeM8a1836tAW+Pqp/ZFsTA5fZHsJZvP2D5g==",
+      "requires": {
+        "@turf/boolean-point-in-polygon": "^6.5.0",
+        "@turf/helpers": "^6.5.0",
+        "@turf/line-intersect": "^6.5.0",
+        "@turf/meta": "^6.5.0",
+        "@turf/polygon-to-line": "^6.5.0"
+      }
+    },
+    "@turf/boolean-intersects": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-intersects/-/boolean-intersects-6.5.0.tgz",
+      "integrity": "sha512-nIxkizjRdjKCYFQMnml6cjPsDOBCThrt+nkqtSEcxkKMhAQj5OO7o2CecioNTaX8EayqwMGVKcsz27oP4mKPTw==",
+      "requires": {
+        "@turf/boolean-disjoint": "^6.5.0",
+        "@turf/helpers": "^6.5.0",
+        "@turf/meta": "^6.5.0"
+      }
+    },
+    "@turf/boolean-point-in-polygon": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-6.5.0.tgz",
+      "integrity": "sha512-DtSuVFB26SI+hj0SjrvXowGTUCHlgevPAIsukssW6BG5MlNSBQAo70wpICBNJL6RjukXg8d2eXaAWuD/CqL00A==",
+      "requires": {
+        "@turf/helpers": "^6.5.0",
+        "@turf/invariant": "^6.5.0"
+      }
+    },
+    "@turf/buffer": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/buffer/-/buffer-6.5.0.tgz",
+      "integrity": "sha512-qeX4N6+PPWbKqp1AVkBVWFerGjMYMUyencwfnkCesoznU6qvfugFHNAngNqIBVnJjZ5n8IFyOf+akcxnrt9sNg==",
+      "requires": {
+        "@turf/bbox": "^6.5.0",
+        "@turf/center": "^6.5.0",
+        "@turf/helpers": "^6.5.0",
+        "@turf/meta": "^6.5.0",
+        "@turf/projection": "^6.5.0",
+        "d3-geo": "1.7.1",
+        "turf-jsts": "*"
+      }
+    },
+    "@turf/center": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/center/-/center-6.5.0.tgz",
+      "integrity": "sha512-T8KtMTfSATWcAX088rEDKjyvQCBkUsLnK/Txb6/8WUXIeOZyHu42G7MkdkHRoHtwieLdduDdmPLFyTdG5/e7ZQ==",
+      "requires": {
+        "@turf/bbox": "^6.5.0",
+        "@turf/helpers": "^6.5.0"
+      }
+    },
+    "@turf/clone": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/clone/-/clone-6.5.0.tgz",
+      "integrity": "sha512-mzVtTFj/QycXOn6ig+annKrM6ZlimreKYz6f/GSERytOpgzodbQyOgkfwru100O1KQhhjSudKK4DsQ0oyi9cTw==",
+      "requires": {
+        "@turf/helpers": "^6.5.0"
+      }
+    },
+    "@turf/helpers": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
+      "integrity": "sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw=="
+    },
+    "@turf/invariant": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.5.0.tgz",
+      "integrity": "sha512-Wv8PRNCtPD31UVbdJE/KVAWKe7l6US+lJItRR/HOEW3eh+U/JwRCSUl/KZ7bmjM/C+zLNoreM2TU6OoLACs4eg==",
+      "requires": {
+        "@turf/helpers": "^6.5.0"
+      }
+    },
+    "@turf/line-intersect": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-6.5.0.tgz",
+      "integrity": "sha512-CS6R1tZvVQD390G9Ea4pmpM6mJGPWoL82jD46y0q1KSor9s6HupMIo1kY4Ny+AEYQl9jd21V3Scz20eldpbTVA==",
+      "requires": {
+        "@turf/helpers": "^6.5.0",
+        "@turf/invariant": "^6.5.0",
+        "@turf/line-segment": "^6.5.0",
+        "@turf/meta": "^6.5.0",
+        "geojson-rbush": "3.x"
+      }
+    },
+    "@turf/line-segment": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-6.5.0.tgz",
+      "integrity": "sha512-jI625Ho4jSuJESNq66Mmi290ZJ5pPZiQZruPVpmHkUw257Pew0alMmb6YrqYNnLUuiVVONxAAKXUVeeUGtycfw==",
+      "requires": {
+        "@turf/helpers": "^6.5.0",
+        "@turf/invariant": "^6.5.0",
+        "@turf/meta": "^6.5.0"
+      }
+    },
+    "@turf/meta": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.5.0.tgz",
+      "integrity": "sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==",
+      "requires": {
+        "@turf/helpers": "^6.5.0"
+      }
+    },
+    "@turf/polygon-to-line": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/polygon-to-line/-/polygon-to-line-6.5.0.tgz",
+      "integrity": "sha512-5p4n/ij97EIttAq+ewSnKt0ruvuM+LIDzuczSzuHTpq4oS7Oq8yqg5TQ4nzMVuK41r/tALCk7nAoBuw3Su4Gcw==",
+      "requires": {
+        "@turf/helpers": "^6.5.0",
+        "@turf/invariant": "^6.5.0"
+      }
+    },
+    "@turf/projection": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/projection/-/projection-6.5.0.tgz",
+      "integrity": "sha512-/Pgh9mDvQWWu8HRxqpM+tKz8OzgauV+DiOcr3FCjD6ubDnrrmMJlsf6fFJmggw93mtVPrZRL6yyi9aYCQBOIvg==",
+      "requires": {
+        "@turf/clone": "^6.5.0",
+        "@turf/helpers": "^6.5.0",
+        "@turf/meta": "^6.5.0"
+      }
+    },
     "@types/eslint": {
       "version": "8.4.5",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.5.tgz",
@@ -4340,6 +4685,11 @@
       "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
       "dev": true,
       "peer": true
+    },
+    "@types/geojson": {
+      "version": "7946.0.8",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.8.tgz",
+      "integrity": "sha512-1rkryxURpr6aWP7R786/UQOkJ3PcpQiWkAXBmdWc7ryFWqN6a4xfK7BtjXvFBKO9LjQ+MWQSWxYeZX1OApnArA=="
     },
     "@types/json-schema": {
       "version": "7.0.11",
@@ -4905,6 +5255,19 @@
       "version": "2.6.20",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.20.tgz",
       "integrity": "sha512-/WwNkdXfckNgw6S5R125rrW8ez139lBHWouiBvX8dfMFtcn6V81REDqnH7+CRpRipfYlyU1CmOnOxrmGcFOjeA=="
+    },
+    "d3-array": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
+      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw=="
+    },
+    "d3-geo": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.7.1.tgz",
+      "integrity": "sha512-O4AempWAr+P5qbk2bC2FuN/sDW4z+dN2wDf9QV3bxQt4M5HfOEeXLgJ/UKQW0+o1Dj8BE+L5kiDbdWUMjsmQpw==",
+      "requires": {
+        "d3-array": "1"
+      }
     },
     "debug": {
       "version": "4.3.4",
@@ -5637,6 +6000,18 @@
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
       "dev": true
+    },
+    "geojson-rbush": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/geojson-rbush/-/geojson-rbush-3.2.0.tgz",
+      "integrity": "sha512-oVltQTXolxvsz1sZnutlSuLDEcQAKYC/uXt9zDzJJ6bu0W+baTI8LZBaTup5afzibEH4N3jlq2p+a152wlBJ7w==",
+      "requires": {
+        "@turf/bbox": "*",
+        "@turf/helpers": "6.x",
+        "@turf/meta": "6.x",
+        "@types/geojson": "7946.0.8",
+        "rbush": "^3.0.1"
+      }
     },
     "geotiff": {
       "version": "2.0.4",
@@ -6823,6 +7198,11 @@
           }
         }
       }
+    },
+    "turf-jsts": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/turf-jsts/-/turf-jsts-1.2.3.tgz",
+      "integrity": "sha512-Ja03QIJlPuHt4IQ2FfGex4F4JAr8m3jpaHbFbQrgwr7s7L6U8ocrHiF3J1+wf9jzhGKxvDeaCAnGDot8OjGFyA=="
     },
     "type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
   },
   "dependencies": {
     "@mdi/font": "5.9.55",
+    "@turf/boolean-intersects": "^6.5.0",
+    "@turf/buffer": "^6.5.0",
     "ol": "^7.1.1-dev.1663363305046",
     "ol-mapbox-style": "^9.1.0",
     "roboto-fontface": "*",

--- a/public/map/style.json
+++ b/public/map/style.json
@@ -338,38 +338,6 @@
       "group": "one"
     }
   }, {
-    "id": "bdfl_l31_begruente_abflusswege-one",
-    "type": "fill",
-    "source": "agrargis",
-    "source-layer": "bdfl_l31_begruente_abflusswege",
-    "paint": {
-      "fill-color": "rgb(108, 143, 235)"
-    },
-    "layout": {
-      "visibility": "none"
-    },
-    "metadata": {
-      "label": "Begrünte Abflusswege",
-      "urlSort": 2,
-      "group": "one"
-    }
-  }, {
-    "id": "bdfl_l33_pufferstreifen_belastete_gewaesser-one",
-    "type": "fill",
-    "source": "agrargis",
-    "source-layer": "bdfl_l33_pufferstreifen_belastete_gewaesser",
-    "paint": {
-      "fill-color": "rgb(147, 248, 104)"
-    },
-    "layout": {
-      "visibility": "none"
-    },
-    "metadata": {
-      "label": "Pufferstreifen belasteter Gewässer",
-      "urlSort": 1,
-      "group": "one"
-    }
-  }, {
     "id": "bdfl_l34_feucht_torfgebiete-one",
     "type": "fill",
     "source": "agrargis",
@@ -402,6 +370,38 @@
        "group": "one"
      }
    }, {
+    "id": "bdfl_l31_begruente_abflusswege-one",
+    "type": "fill",
+    "source": "agrargis",
+    "source-layer": "bdfl_l31_begruente_abflusswege",
+    "paint": {
+      "fill-color": "rgb(108, 143, 235)"
+    },
+    "layout": {
+      "visibility": "none"
+    },
+    "metadata": {
+      "label": "Begrünte Abflusswege",
+      "urlSort": 2,
+      "group": "one"
+    }
+  }, {
+    "id": "bdfl_l33_pufferstreifen_belastete_gewaesser-one",
+    "type": "fill",
+    "source": "agrargis",
+    "source-layer": "bdfl_l33_pufferstreifen_belastete_gewaesser",
+    "paint": {
+      "fill-color": "rgb(147, 248, 104)"
+    },
+    "layout": {
+      "visibility": "none"
+    },
+    "metadata": {
+      "label": "Pufferstreifen belasteter Gewässer",
+      "urlSort": 1,
+      "group": "one"
+    }
+  }, {
     "id": "stehende_gewaesser-one",
     "type": "fill",
     "source": "agrargis",
@@ -460,6 +460,25 @@
         "rgb(238, 90, 78)"
       ],
       "line-width": 2
+    }
+  }, {
+    "id": "invekos_schlaege_2022_polygon-bio",
+    "type": "fill",
+    "source": "agrargis",
+    "source-layer": "invekos_schlaege_2022_polygon",
+    "filter": ["==", "kz_bio_oepul_jn", "J"],
+    "paint": {
+      "fill-color": "red",
+      "fill-outline-color": "rgb(139, 0, 0)"
+    },
+    "layout": {
+      "visibility": "none"
+    },
+    "metadata": {
+      "label": "ÖPUL Bio-Schläge",
+      "urlSort": 16,
+      "displaySort": 1,
+      "group": "one"
     }
   }, {
     "id": "invekos_schlaege_2022_polygon-line-selected",

--- a/src/components/TheSchlagInfoPanel.vue
+++ b/src/components/TheSchlagInfoPanel.vue
@@ -64,7 +64,7 @@
             class="pa-2 pb-1"
             cols="7"
           >
-            {{ schlagInfo.snar_bezeichnung }}
+            <b v-if="schlagInfo.kz_bio_oepul_jn === 'J'">BIO </b>{{ schlagInfo.snar_bezeichnung }}
           </v-col>
           <v-col
             class="px-2"

--- a/src/components/TheTopicPanel.vue
+++ b/src/components/TheTopicPanel.vue
@@ -93,6 +93,11 @@
                   class="denseBox"
                   density="compact"
                   :class="{fat : schlagInfo && topic.inSchlagExtent}"
+                /><v-label
+                  v-if="topic.visible && topic.label === 'ÖPUL Bio-Schläge'"
+                  class="pl-7 pb-1 bio-warning"
+                  text="Die rot dargestellten Flächen werden biologisch bewirtschaftet. Es ist daher
+bei der Ausbringung von Betriebsmitteln besondere Sorgfalt walten zu lassen."
                 />
               </v-col><v-col
                 cols="2"
@@ -113,7 +118,7 @@
             v-model="onlyTopicsInSchlagExtent"
             density="compact"
             hide-details
-            label="Nur für den gewählten Schlag mögliche Themen"
+            label="Nur für den gewählten Schlag interessante Themen"
             :disabled="!schlagInfo"
           />
         </div>
@@ -243,6 +248,9 @@ function urlSort(a, b) {
 const onlyTopicsInSchlagExtent = ref(false);
 
 function setVisible(value) {
+  if (!value) {
+    return;
+  }
   const [topicsVisible, gradientsVisible] = value.split(',');
   topics.slice(0).sort(urlSort).forEach((topic, i) => {
     topic.visible = topicsVisible.charAt(i) === '1';
@@ -467,6 +475,13 @@ mapReady.then(() => setVisible(route.params.visible));
   .v-radio.v-selection-control.v-selection-control--dirty .v-label {
     color: #000;
     opacity: .9;
+  }
+  .bio-warning {
+    color: red;
+    font-weight: bold;
+    opacity: 1;
+    white-space: normal;
+    cursor: inherit;
   }
 
 </style>


### PR DESCRIPTION
Mit diesem Pull Request werden Bio-Schläge hinzugefügt. Diese werden in der Themenauswahl als 1. Thema angezeigt, und es wird bei gewählten Bio-Schlägen auch ein Hinweis bezüglich Achtsamkeit bei der Bewirtschaftung benachbarter Schläge angezeigt.

Bisher wurde nur ein ungefährer Puffer um die Schläge verwendet, um möglicherweise schlagrelevante Themen zu filtern. Nun werden echte Puffer verwendet, und zwar 10 m für alle Themen außer Bio-Schläge, und 100 m für Bio-Schläge.