### PR TITLE
Make clicks on checkbox and label consistent for gradients

### DIFF
--- a/src/components/TheTopicPanel.vue
+++ b/src/components/TheTopicPanel.vue
@@ -173,7 +173,7 @@ bei der Ausbringung von Betriebsmitteln besondere Sorgfalt walten zu lassen."
               :class="{'selected' : schlagInfo && gradient.inSchlag,
                        'active' : gradient.visible,
                        'disabled': mapView.zoom < 9}"
-              @click="gradient.visible = !gradient.visible"
+              @click="gradient.visible = mapView.zoom < 9 ? gradient.visible : !gradient.visible"
             >
               {{ gradient.label }}
             </v-col>


### PR DESCRIPTION
Derzeit ist es bei der Hangneigungen Ansicht so, dass auf Zoomstufen < 9 zwar das Klicken auf die Checkbox unterbunden ist, nicht aber auf das Label. Dieser Pull Request stellt hier Konsistenz her, indem auf inaktive Labels (also bei Zoom < 9) nicht geklickt werden kann.