### PR TITLE
Change Schlag selection outline to a less conflicting color

### DIFF
--- a/public/map/style.json
+++ b/public/map/style.json
@@ -545,7 +545,7 @@
       "line-color": [
         "case",
         ["boolean", ["feature-state", "selected"], false],
-        "#FF9900",
+        "#65000B",
         "rgba(0, 0, 0, 0)"
       ],
       "line-width": 5


### PR DESCRIPTION
Die Schlag Umrandung beim selektierten Schlag ist bei manchen gewählten Themen sehr schlecht lesbar. Sie wird nun in ein dunkles Rotbraun ("Rosewood") geändert, das gut in Kombination mit allen Themen und Hintergründen sichtbar ist.