### PR TITLE
Render gradients directly from GeoTIFF

### DIFF
--- a/public/map/style.json
+++ b/public/map/style.json
@@ -38,7 +38,10 @@
         "https://inspire.lfrz.gv.at/000504/ows?SERVICE=WMS&SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image%2Fpng&TRANSPARENT=true&LAYERS=neigungsklassen&STYLES=&WIDTH=512&HEIGHT=512&CRS=EPSG%3A3857&BBOX={bbox-epsg-3857}"
       ],
       "minzoom": 9,
-      "maxzoom": 14
+      "maxzoom": 14,
+      "layout": {
+        "visibility": "none"
+      }
     },
     "agrargis": {
       "type": "vector",
@@ -72,7 +75,9 @@
     "type": "raster",
     "source": "neigungsklassen",
     "minzoom": 9,
-    "layout": { "visibility": "none" },
+    "layout": {
+      "visibility": "none"
+    },
     "metadata": {
       "group": "multi",
       "classes": [{
@@ -110,6 +115,9 @@
     "paint": {
       "fill-color": "#98e600"
     },
+    "layout": {
+      "visibility": "none"
+    },
     "metadata": {
       "label": "Benachteiligtes Gebiet – Berggebiet",
       "urlSort": 17,
@@ -124,6 +132,9 @@
     "paint": {
       "fill-color": "#e69800"
     },
+    "layout": {
+      "visibility": "none"
+    },
     "metadata": {
       "label": "Benachteiligtes Gebiet – Kleines Gebiet",
       "urlSort": 18,
@@ -137,6 +148,9 @@
     "filter": ["==", "bengebcode", 4],
     "paint": {
       "fill-color": "#267300"
+    },
+    "layout": {
+      "visibility": "none"
     },
     "metadata": {
       "label": "Benachteiligtes Gebiet – Sonstiges",
@@ -183,6 +197,9 @@
     "filter": ["==", "in_napv", 1],
     "paint": {
       "fill-color": "#89ce64"
+    },
+    "layout": {
+      "visibility": "none"
     },
     "metadata": {
       "label": "Nitrataktionsprogramm",

--- a/src/composables/useLayers.js
+++ b/src/composables/useLayers.js
@@ -1,6 +1,5 @@
 import { getLayer, updateMapboxLayer } from 'ol-mapbox-style';
 import { computed, ref, watch } from 'vue';
-import { gradients } from './useGradient';
 import { map, mapReady, mapView } from './useMap';
 import { topics } from './useTopics';
 
@@ -70,19 +69,6 @@ watch(topics, (value) => {
     layer.layout = { ...layer.layout, visibility: visible ? 'visible' : 'none' };
     updateMapboxLayer(map, layer);
   });
-});
-
-watch(gradients, (value) => {
-  const mapboxLayer = map.get('mapbox-style').layers.find((l) => l.id === 'neigungsklassen');
-  const style = {
-    color: mapboxLayer.metadata.classes.reduce((acc, cur, i) => {
-      acc.splice(acc.length - 1, 0, ['==', ['band', 1], i + 1], value[i].visible ? cur.color : [0, 0, 0, 0]);
-      return acc;
-    }, ['case', [0, 0, 0, 0]]),
-  };
-  const layer = getLayer(map, mapboxLayer.id);
-  layer.setStyle(style);
-  layer.setVisible(value.some((v) => v.visible));
 });
 
 export function useLayers() {

--- a/src/composables/useMap.js
+++ b/src/composables/useMap.js
@@ -13,8 +13,6 @@ import VectorTileLayer from 'ol/layer/VectorTile';
 import { MapboxVector } from 'ol/layer';
 import proj4 from 'proj4';
 import { register } from 'ol/proj/proj4';
-import WebGLTileLayer from 'ol/layer/WebGLTile';
-import { GeoTIFF } from 'ol/source';
 import { INITIAL_EXTENT } from '../constants';
 
 /**
@@ -77,43 +75,11 @@ map.addLayer(new MapboxVector({
 }));
 
 export const mapReady = apply(map, './map/style.json').then(() => {
-  const geotiff = new GeoTIFF({
-    sources: [{
-      url: './map/raster/ALS_DNM_AT_COG_reclassified_220820.tif',
-    }],
-    normalize: false,
-    interpolate: false,
-    transition: 0,
-  });
   const { layers } = map.get('mapbox-style');
   layers.forEach((layer) => {
-    if (layer.metadata?.group === 'base') {
-      getSource(map, layer.source).tileOptions.transition = undefined;
-    }
+    getSource(map, layer.source).tileOptions.transition = undefined;
   });
-  const mapboxLayer = map.get('mapbox-style').layers.find((l) => l.id === 'neigungsklassen');
-  const originalLayer = getLayer(map, mapboxLayer.id);
-  const gradientLayer = new WebGLTileLayer({
-    properties: {
-      'mapbox-source': originalLayer.get('mapbox-source'),
-      'mapbox-layers': originalLayer.get('mapbox-layers'),
-    },
-    source: geotiff,
-    visible: originalLayer.getVisible(),
-    opacity: originalLayer.getOpacity(),
-    minResolution: originalLayer.getMinResolution(),
-    maxResolution: originalLayer.getMaxResolution(),
-    style: {
-      color: mapboxLayer.metadata.classes.reduce((acc, cur, i) => {
-        acc.splice(acc.length - 1, 0, ['==', ['band', 1], i + 1], cur.color);
-        return acc;
-      }, ['case', [0, 0, 0, 0]]),
-    },
-  });
-  const layerIndex = map.getLayers().getArray().indexOf(originalLayer);
-  map.getLayers().removeAt(layerIndex);
-  map.getLayers().insertAt(layerIndex, gradientLayer);
-
+  getLayer(map, 'neigungsklassen').setSource(null);
   getSource(map, 'agrargis').overlaps_ = false; // eslint-disable-line
 });
 


### PR DESCRIPTION
This pull request gets rid of the WebGLTile Layer and the GeoTIFF source. Instead, the gradients are now rendered directly from geotiff.js's `getRasters()` output, using a simple `tileLoadFunction`.

This change was made because now, the visual gradient output matches the calculated contributions of each gradient class to a Schlag's area .