### PR TITLE
Fix topic updates when tiles are loaded

### DIFF
--- a/src/composables/useTopics.js
+++ b/src/composables/useTopics.js
@@ -125,10 +125,12 @@ watch(mapView, () => {
     if (tilesLoading === undefined || tilesLoading > 0) {
       const source = getSource(map, 'agrargis');
       source.on(['tileloadend', 'tileloaderror'], function onLoaded() {
-        if (!tilesLoading) {
-          source.un(['tileloadend', 'tileloaderror'], onLoaded);
-          updateTopicsInExtent();
-        }
+        setTimeout(() => {
+          if (!tilesLoading) {
+            source.un(['tileloadend', 'tileloaderror'], onLoaded);
+            updateTopicsInExtent();
+          }
+        }, 150);
       });
     } else {
       updateTopicsInExtent();


### PR DESCRIPTION
Derzeit werden die relevanten/verfügbaren Themen nicht immer korrekt aktualisiert, wenn die Kacheln für den jeweiligen Kartenausschnitt geladen sind. Dieses Problem wird hier behoben.

Der Grund für das Problem war, dass ein Rückgang von `tilesLoading` auf `0` auch beim Laden weiterer Kacheln zwischendurch passieren kann. Durch verzögertes Aktualisieren dieser Variable wird verhindert, dass dieser Status zum Beurteilen, ob alles geladen ist, herangezogen wird.