### PR TITLE
Add Natura 2000 to GLOEZ category

### DIFF
--- a/public/map/style.json
+++ b/public/map/style.json
@@ -198,10 +198,10 @@
       "visibility": "none"
     },
     "metadata": {
-      "label": "Natura 2000",
+      "label": "9 Natura 2000",
       "urlSort": 22,
       "group": "one",
-      "category": "Sonstige Informationen"
+      "category": "GLÖZ"
     }
   }, {
     "id": "natura2000_sg",
@@ -215,10 +215,10 @@
       "visibility": "none"
     },
     "metadata": {
-      "label": "Natura 2000",
+      "label": "9 Natura 2000 Sonstige Gebiete",
       "urlSort": 23,
       "group": "one",
-      "category": "Sonstige Informationen"
+      "category": "GLÖZ"
     }
   }, {
     "id": "bdfl_l16_grundwasserschutz_acker-one",


### PR DESCRIPTION
Die Natura 2000 Layer sind nun getrennt in "Natura 2000" und "Natura 2000 Sonstige Gebiete", und der Kategorie GLÖZ (9) zugeordnet.