### PR TITLE
Retrieve feature from inspire when not found in initial map extent

### DIFF
--- a/src/components/TheSchlagInfoPanel.vue
+++ b/src/components/TheSchlagInfoPanel.vue
@@ -202,10 +202,10 @@ function center() {
 }
 
 function setSchlagId(id) {
-  if (Number(id) !== schlagInfo.value?.id) {
+  if (id !== schlagInfo.value?.localID) {
     schlagInfo.value = id ? {
       loading: true,
-      id: Number(id),
+      localID: id,
     } : null;
   }
 }
@@ -216,8 +216,8 @@ const canCenter = computed(() => schlagInfo.value?.extent && (!equals(
 ) || mapView.value.zoom < 12));
 
 watch(schlagInfo, (value) => {
-  if (value?.id !== Number(route.params.schlagId)) {
-    router.push({ params: { ...route.params, schlagId: value?.id } });
+  if (value?.localID !== route.params.schlagId) {
+    router.push({ params: { ...route.params, schlagId: value?.localID } });
   }
   if (value && !value.loading) {
     emit('schlag', true);


### PR DESCRIPTION
Verwendung der localID aus der inspire_id, um auch in anderen Applikationen (EUDR) die originalen Feature-Geometrien holen zu können, oder - wie in diesem Fall - auch bei Zoom/Center außerhalb des Bereiches, wo eine localID in den Kacheln gefunden wird, den Status aus dem Hash der URL korrekt wiederherzustellen.